### PR TITLE
ci: replace the dead live smoke test with the unit tests, fix CODEOWNERS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ on:
       - main
       - master
 
-permissions: write-all
+permissions:
+  contents: read
 
 jobs:
   test-typescript:
@@ -40,28 +41,6 @@ jobs:
         id: npm-lint
         run: npm run lint
 
-      # - name: Test
-      #   id: npm-ci-test
-      #   run: npm run ci-test
-
-  test-action:
-    name: GitHub Actions Test
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        id: checkout
-        uses: actions/checkout@v4
-
-      - name: Test Local Action
-        id: test-action
-        uses: ./
-        with:
-          api-token: ${{ secrets.LOGGIA_API_TOKEN }}
-          test-suite-id: ${{ secrets.LOGGIA_TEST_SUITE_ID }}
-          environment-id: ${{ secrets.LOGGIA_ENVIRONMENT_ID }}
-          environment-url: ${{ secrets.LOGGIA_TEST_SUITE_ENVIRONMENT_URL }}
-
-      - name: Print Output
-        id: output
-        run: echo "${{ steps.test-action.outputs.time }}"
+      - name: Test
+        id: npm-ci-test
+        run: npm run ci-test

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,4 @@
 ############################################################################
 
 # Default owners, unless a later match takes precedence.
-* @actions/actions-oss-maintainers
+* @feng-shiplight


### PR DESCRIPTION
Follow-up to #38. These two commits were meant to ride along with it, but #38 merged first.

## The CI job cannot be repointed, so it is removed

`GitHub Actions Test` ran the action for real against `secrets.LOGGIA_*`. The API now answers:

```
[shiplight] starting single test run ...
##[error]Failed to start batch test run: Batch test run not found
```

The suite and environment those secrets name belong to Shiplight Cloud v1 and no longer exist. There is nowhere else to point it: this action only speaks to the v1 API, and the current platform's CI path does not use this action at all, so no v2 target exists to swap in.

Left alone, this job fails on every pull request to this repo forever, which trains everyone to ignore a red X.

## What replaces it

The unit tests that were already sitting commented out in the same workflow:

```diff
-      # - name: Test
-      #   id: npm-ci-test
-      #   run: npm run ci-test
+      - name: Test
+        id: npm-ci-test
+        run: npm run ci-test
```

They pass and need no live backend:

```
PASS __tests__/main.test.ts
  main.ts
    ✓ Sets a failed status for missing API token
    ✓ Parses test-context lines and trims surrounding whitespace
    ✓ Rejects test-context lines with an empty key

Tests: 3 passed, 3 total
```

Three tests is thin, and statement coverage across `src/` is 13.5%. But green and testing a little beats red and testing nothing, and it gives anyone adding coverage later a job to add it to.

## Workflow permissions

Dropped from `permissions: write-all` to `contents: read`. With the smoke test gone, nothing in this workflow comments on a pull request, so nothing needs write.

## CODEOWNERS

```diff
-* @actions/actions-oss-maintainers
+* @feng-shiplight
```

The old value is the `actions/typescript-action` template default. That team does not exist in this org, so every PR here landed with no reviewer requested, including #38.

Branch protection has `require_code_owner_reviews: false`, so this changes who gets auto-requested, not who is allowed to approve.

## Still template leftovers, not touched here

`package.json` identifies as `"name": "typescript-action"` with `homepage`, `repository`, and `bugs` all pointing at `actions/typescript-action`. Harmless (the package is `private: true` and never published) but wrong if anyone reads it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)